### PR TITLE
Moved post login actions to a route so we automatically get 'loading' screen logic

### DIFF
--- a/addon/router/router.js
+++ b/addon/router/router.js
@@ -6,6 +6,7 @@ Router.map(function() {
   this.resource('i18n', { path: '/i18n' });
   this.resource('logout', { path: '/logout' });
   this.route('login');
+  this.route('post_login');
   this.route('resend');
   this.route('offline');
   this.route('authenticate');

--- a/app/controllers/authenticate.js
+++ b/app/controllers/authenticate.js
@@ -10,6 +10,8 @@ export default Ember.Controller.extend({
     return config.APP.HK_COUNTRY_CODE + this.get('mobilePhone');
   }.property('mobilePhone'),
 
+  attemptedTransition: null,
+
   actions: {
 
     authenticateUser: function(){
@@ -17,52 +19,26 @@ export default Ember.Controller.extend({
       var pin = this.get('pin');
       var otp_auth_key = this.get('session.otpAuthKey');
       var _this = this;
-      var attemptedTransition = _this.get('attemptedTransition');
 
+      var loadingView = this.container.lookup('view:loading').append();
       new AjaxPromise("/auth/verify", "POST", null, {pin: pin, otp_auth_key: otp_auth_key})
         .then(function(data) {
           _this.setProperties({pin:null});
           _this.set('session.authToken', data.jwt_token);
           _this.set('session.otpAuthKey', null);
           _this.store.pushPayload(data.user);
-
-          Ember.run(function(){
-            _this.get('controllers.application').send('logMeIn');
-          });
-
-          _this.transitionToRoute('loading');
-
-          var promises = config.APP.PRELOAD_AUTHORIZED_TYPES
-            .map(function(type) { return _this.store.find(type); });
-
-          Ember.RSVP.allSettled(promises).finally(function() {
-            // After login, redirect user to requested url
-            if (attemptedTransition) {
-              attemptedTransition.retry();
-              _this.set('attemptedTransition', null);
-            } else {
-              var currentUser = _this.get('session.currentUser');
-              if (currentUser.get('isStaff')) {
-                var myOffers = _this.store.all('offer').filterBy('reviewedBy.id', currentUser.get('id'));
-                if(myOffers.get('length') > 0) {
-                  _this.transitionToRoute('my_list');
-                } else {
-                  _this.transitionToRoute('offers');
-                }
-              } else {
-                _this.transitionToRoute('/offers');
-              }
-            }
-          });
           _this.setProperties({pin: null});
+          _this.transitionToRoute('post_login');
         })
         .catch(function(jqXHR) {
           Ember.$('#pin').closest('div').addClass('error');
+          _this.setProperties({pin: null});
           if (jqXHR.status === 422 && jqXHR.responseJSON.errors && jqXHR.responseJSON.errors.pin) {
             _this.get("alert").show(jqXHR.responseJSON.errors.pin);
           }
           console.log("Unable to authenticate");
-        });
+        })
+        .finally(() => loadingView.destroy());
     },
 
     resendPin: function() {

--- a/app/routes/post_login.js
+++ b/app/routes/post_login.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import config from '../config/environment';
+
+export default Ember.Route.extend({
+
+  beforeModel: function() {
+    var _this = this;
+    Ember.run(function(){
+      _this.controllerFor('application').send('logMeIn');
+    });
+    var promises = config.APP.PRELOAD_AUTHORIZED_TYPES
+      .map(function(type) { return _this.store.find(type); });
+    return Ember.RSVP.allSettled(promises);
+  },
+
+  afterModel: function() {
+    // After everthying has been loaded, redirect user to requested url
+    var attemptedTransition = this.controllerFor('login').get('attemptedTransition');
+    if (attemptedTransition) {
+      attemptedTransition.retry();
+      this.set('attemptedTransition', null);
+    } else {
+      var currentUser = this.get('session.currentUser');
+      if (currentUser.get('isStaff')) {
+        var myOffers = this.store.all('offer').filterBy('reviewedBy.id', currentUser.get('id'));
+        if(myOffers.get('length') > 0) {
+          this.transitionTo('my_list');
+        } else {
+          this.transitionTo('offers');
+        }
+      } else {
+        this.transitionTo('/offers');
+      }
+    }
+  }
+
+});


### PR DESCRIPTION
@swatijadhav could you review this PR for me? Been a while since I've written Ember code.

The main aim is to remove utilise Ember's automatic loading routes when loading data immediately after the PIN has been entered sucessfully. Before we were doing this manually but this was bad because the user could click the back button and get a loading page (a real user got caught out by this in a test). Now the loading spinner shows, disappears once the data has loaded, clicking back goes to the pin screen (as expected)