### PR TITLE
Redirect users to login instead of showing a modal

### DIFF
--- a/addon/locales/en/translations.coffee
+++ b/addon/locales/en/translations.coffee
@@ -42,7 +42,6 @@ I18nTranslationsEn =
   "okay": "Okay"
   "cancel": "Cancel"
   "save": "Save"
-  "must_login": "You must login!"
   "unexpected_error": "Something went wrong"
   "all": "All"
   "thank_you": "Thank you"

--- a/addon/locales/zh-tw/translations.coffee
+++ b/addon/locales/zh-tw/translations.coffee
@@ -42,7 +42,6 @@ I18nTranslationsZhTw =
   "okay": "確定"
   "cancel": "取消"
   "save": "儲存"
-  "must_login": "請先登入"
   "unexpected_error": "出錯"
   "all": "全部"
   "thank_you": "謝謝"

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,7 +9,6 @@ export default Ember.Route.extend(preloadDataMixin, {
   isOfflineErrAlreadyShown: false,
   logger: Ember.inject.service(),
   messageBox: Ember.inject.service(),
-  isMustLoginAlreadyShown: false,
   isalreadyLoggedinShown: false,
 
   _loadDataStore: function() {
@@ -36,14 +35,11 @@ export default Ember.Route.extend(preloadDataMixin, {
     var storageHandler = function(object) {
       var currentPath = window.location.href;
       var authToken = window.localStorage.getItem('authToken');
-      if (!authToken && window.location.pathname !== "/" && window.location.pathname !== "/register" && !object.get('isMustLoginAlreadyShown') && !object.isUnAuthenticatedPath(currentPath)) {
-        object.set('isMustLoginAlreadyShown', true);
+      if (!authToken && window.location.pathname !== "/" && window.location.pathname !== "/register" && !object.isUnAuthenticatedPath(currentPath)) {
         object.store.unloadAll('user_profile');
-        object.get('messageBox').alert(object.get("i18n").t('must_login'), () => {
-          object.session.clear();
-          object.store.unloadAll();
-          window.location.reload();
-        });
+        object.session.clear();
+        object.store.unloadAll();
+        window.location.reload();
       } else if (object.get("isalreadyLoggedinShown") && authToken && !(currentPath.indexOf("offer") >= 0) && object.isUnAuthenticatedPath(currentPath)) {
         object.set("isalreadyLoggedinShown", true);
         object.get('messageBox').alert("Logged in from another window, press ok to refresh.", () => {

--- a/app/routes/authorize.js
+++ b/app/routes/authorize.js
@@ -7,12 +7,11 @@ export default Ember.Route.extend({
   beforeModel(transition) {
     if (!this.session.get('isLoggedIn')) {
       transition.abort();
-      this.get('messageBox').alert(this.get("i18n").t('must_login'), () => {
-        var loginController = this.controllerFor('login');
-        loginController.set('attemptedTransition', transition);
-        this.transitionTo('login');
-      });
+      var loginController = this.controllerFor('login');
+      loginController.set('attemptedTransition', transition);
+      this.transitionTo('login');
       return false;
     }
+    return true;
   }
 });


### PR DESCRIPTION
Currrently, if user is logged out and tries to visit any page, we show "You must login!" modal, which looks rude, so this PR removes that modal, and automatically redirects them to the login page.

Keeping in mind which the user was trying to visit, post login user is redirected to that page.