### PR TITLE
Admin- GCW-2666: Provide filters for offer search UI

### DIFF
--- a/app/adapters/offer.js
+++ b/app/adapters/offer.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from "./application";
+import config from '../config/environment';
+
+export default ApplicationAdapter.extend({
+
+  urlForQuery: function(query, modelName){
+    const { slug } = query;
+    if (modelName === "offer" && slug === "search") {
+      return `${config.APP.API_HOST_URL}/${config.APP.NAMESPACE}/offers/search`;
+    }
+    return this._super(...arguments);
+  }
+
+});


### PR DESCRIPTION
Hi Team,
This PR is for ticket GCW-2666: Provide filters for search UI on Admin app. I have added adapter to create url `offers/search`. I have chosen Ember data query over `ajaxPromise` because `queryParams` was very long and had many parameters which makes it hard to maintain different params in url .
`Eg: ajaxPromise("GET", "/offers/search?states=submitted,reviewed&priority...)`. 

Please review the PR and let me know if any change is required.
Thanks