### PR TITLE
Remove unused input causing error popup

### DIFF
--- a/app/templates/item/item_edit_form.hbs
+++ b/app/templates/item/item_edit_form.hbs
@@ -12,7 +12,6 @@
 
         <div class="small-8 large-10 columns">
           {{input-ui-control-with-counter type="textarea" value=formData.donorDescription label="" name="donorDescription" rows=5 placeholder=itemDescriptionPlaceholder maxlength="180" required='true' }}
-          {{input type="hidden" value=offer.id name="offerId" }}
         </div>
       </div>
 


### PR DESCRIPTION
This hidden input isn't in use, and the `offer` object doesn't exist (it's named `model`)
In some scenarios the input would try to write to `offer.id` which would fail and cause a popup