### PR TITLE
use computed property for computed name

### DIFF
--- a/app/models/offer.js
+++ b/app/models/offer.js
@@ -72,9 +72,7 @@ export default DS.Model.extend({
 	userName: attr('string'),
 	userPhone: attr('string'),
 
-	companyName: Ember.computed("company", function(){
-		return this.get("company.name");
-	}),
+	companyName: Ember.computed.alias("company.name"),
 
 	crossroadsTruckCost: Ember.computed('crossroadsTransport', function() {
 		return this.get('crossroadsTransport.cost');

--- a/app/models/offer.js
+++ b/app/models/offer.js
@@ -72,6 +72,10 @@ export default DS.Model.extend({
 	userName: attr('string'),
 	userPhone: attr('string'),
 
+	companyName: Ember.computed("company", function(){
+		return this.get("company.name");
+	}),
+
 	crossroadsTruckCost: Ember.computed('crossroadsTransport', function() {
 		return this.get('crossroadsTransport.cost');
 	}),

--- a/app/models/offer.js
+++ b/app/models/offer.js
@@ -72,7 +72,9 @@ export default DS.Model.extend({
 	userName: attr('string'),
 	userPhone: attr('string'),
 
-	companyName: Ember.computed.alias("company.name"),
+	companyName: Ember.computed('company', function () {
+		return this.get('company.name');
+	}),
 
 	crossroadsTruckCost: Ember.computed('crossroadsTransport', function() {
 		return this.get('crossroadsTransport.cost');


### PR DESCRIPTION
We were earlier using `offer.company.name` for displaying name on donor_details screen. Due to which wrong company name used to get displayed on the donor_details screen.

This PR fixes that issue. Please review