### PR TITLE
Fix: errors coming from the backend bubble up to the modals

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,21 +1,45 @@
-import Ember from 'ember';
-import config from '../config/environment';
-import ActiveModelAdapter from 'active-model-adapter';
+import Ember from "ember";
+import config from "../config/environment";
+import ActiveModelAdapter from "active-model-adapter";
+import _ from "lodash";
 
 export default ActiveModelAdapter.extend({
-
   namespace: config.APP.NAMESPACE,
-  host:      config.APP.API_HOST_URL,
-  session:   Ember.inject.service(),
+  host: config.APP.API_HOST_URL,
+  session: Ember.inject.service(),
+  i18n: Ember.inject.service(),
 
-  headers: Ember.computed("session.authToken", function(){
+  headers: Ember.computed("session.authToken", function() {
     return {
-      "Authorization":  `Bearer ${this.get('session.authToken')}`,
-      "Accept-Language": this.get('session.language'),
+      Authorization: `Bearer ${this.get("session.authToken")}`,
+      "Accept-Language": this.get("session.language"),
       "X-GOODCITY-APP-NAME": config.APP.NAME,
       "X-GOODCITY-APP-VERSION": config.APP.VERSION,
       "X-GOODCITY-APP-SHA": config.APP.SHA,
       "X-GOODCITY-APP-SHARED-SHA": config.APP.SHARED_SHA
     };
-  })
+  }),
+
+  handleResponse(status, headers, responseBody) {
+    if (status >= 400) {
+      // Errors coming from the adapter do not carry on the message of the server eror
+      // The same message ends up apearing on every page whenever the backend returns an error.
+      //
+      // This returns a normal ember error, with the same format as before, with our own messages inside
+      //
+      return new DS.AdapterError([
+        {
+          detail: responseBody,
+          status: status,
+          title: _.get(
+            responseBody,
+            "error",
+            this.get("i18n").t("unexpected_error")
+          )
+        }
+      ]);
+    }
+
+    return this._super(...arguments);
+  }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,12 @@
-import Ember from 'ember';
-import preloadDataMixin from '../mixins/preload_data';
+import Ember from "ember";
+import _ from "lodash";
+import preloadDataMixin from "../mixins/preload_data";
 const { getOwner } = Ember;
+
+const getString = (obj, path) => {
+  const val = _.get(obj, path);
+  return val && _.isString(val) ? val : null;
+};
 
 export default Ember.Route.extend(preloadDataMixin, {
   cordova: Ember.inject.service(),
@@ -12,44 +18,70 @@ export default Ember.Route.extend(preloadDataMixin, {
   isalreadyLoggedinShown: false,
 
   _loadDataStore: function() {
-    return this.preloadData(true).catch(error => {
-      if (error.status === 0 || (error.errors && error.errors[0].status === "0")) {
-        this.transitionTo("offline");
-      } else {
-        this.handleError(error);
-      }
-    }).finally(() => {
-      // don't know why but placing this before preloadData on iPhone 6 causes register_device request to fail with status 0
-      if (this.session.get('isLoggedIn')) {
-        this.get("cordova").appLoad();
-      }
-    });
+    return this.preloadData(true)
+      .catch(error => {
+        if (
+          error.status === 0 ||
+          (error.errors && error.errors[0].status === "0")
+        ) {
+          this.transitionTo("offline");
+        } else {
+          this.handleError(error);
+        }
+      })
+      .finally(() => {
+        // don't know why but placing this before preloadData on iPhone 6 causes register_device request to fail with status 0
+        if (this.session.get("isLoggedIn")) {
+          this.get("cordova").appLoad();
+        }
+      });
   },
 
   isUnAuthenticatedPath(currentPath) {
-    return (currentPath.indexOf("login") >= 0 || currentPath.indexOf("authenticate") >= 0 || currentPath.indexOf("pics") >= 0 || currentPath.indexOf("terms_and_conditions") >= 0);
+    return (
+      currentPath.indexOf("login") >= 0 ||
+      currentPath.indexOf("authenticate") >= 0 ||
+      currentPath.indexOf("pics") >= 0 ||
+      currentPath.indexOf("terms_and_conditions") >= 0
+    );
   },
 
   init() {
     var _this = this;
     var storageHandler = function(object) {
       var currentPath = window.location.href;
-      var authToken = window.localStorage.getItem('authToken');
-      if (!authToken && window.location.pathname !== "/" && window.location.pathname !== "/register" && !object.isUnAuthenticatedPath(currentPath)) {
-        object.store.unloadAll('user_profile');
+      var authToken = window.localStorage.getItem("authToken");
+      if (
+        !authToken &&
+        window.location.pathname !== "/" &&
+        window.location.pathname !== "/register" &&
+        !object.isUnAuthenticatedPath(currentPath)
+      ) {
+        object.store.unloadAll("user_profile");
         object.session.clear();
         object.store.unloadAll();
         window.location.reload();
-      } else if (object.get("isalreadyLoggedinShown") && authToken && !(currentPath.indexOf("offer") >= 0) && object.isUnAuthenticatedPath(currentPath)) {
+      } else if (
+        object.get("isalreadyLoggedinShown") &&
+        authToken &&
+        !(currentPath.indexOf("offer") >= 0) &&
+        object.isUnAuthenticatedPath(currentPath)
+      ) {
         object.set("isalreadyLoggedinShown", true);
-        object.get('messageBox').alert("Logged in from another window, press ok to refresh.", () => {
-          window.location.reload();
-        });
+        object
+          .get("messageBox")
+          .alert("Logged in from another window, press ok to refresh.", () => {
+            window.location.reload();
+          });
       }
     };
-    window.addEventListener("storage", function() {
-      storageHandler(_this);
-    }, false);
+    window.addEventListener(
+      "storage",
+      function() {
+        storageHandler(_this);
+      },
+      false
+    );
   },
 
   checkSafariPrivateBrowser() {
@@ -60,7 +92,7 @@ export default Ember.Route.extend(preloadDataMixin, {
       this.get("messageBox").alert(this.get("i18n").t("QuotaExceededError"));
     }
     if (localStrg) {
-      localStrg.removeItem('test');
+      localStrg.removeItem("test");
     }
   },
 
@@ -69,7 +101,7 @@ export default Ember.Route.extend(preloadDataMixin, {
     this.checkSafariPrivateBrowser();
     if (transition.queryParams.ln) {
       language = transition.queryParams.ln === "zh-tw" ? "zh-tw" : "en";
-      this.set('session.language', language);
+      this.set("session.language", language);
     }
 
     language = this.session.get("language") || "en";
@@ -82,7 +114,10 @@ export default Ember.Route.extend(preloadDataMixin, {
   afterModel() {
     if (this.get("session.isAdminApp")) {
       this.loadStaticData(true).catch(error => {
-        if (error.status === 0 || (error.errors && error.errors[0].status === "0")) {
+        if (
+          error.status === 0 ||
+          (error.errors && error.errors[0].status === "0")
+        ) {
           this.transitionTo("offline");
         } else {
           this.handleError(error);
@@ -94,34 +129,33 @@ export default Ember.Route.extend(preloadDataMixin, {
   renderTemplate() {
     this.render(); // default template
 
-    this.render('notifications', { // the template to render
-      into: 'application', // the template to render into
-      outlet: 'notifications', // the name of the outlet in that template
-      controller: 'notifications' // the controller to use for the template
+    this.render("notifications", {
+      // the template to render
+      into: "application", // the template to render into
+      outlet: "notifications", // the name of the outlet in that template
+      controller: "notifications" // the controller to use for the template
     });
 
     if (this.get("session.isAdminApp")) {
-      this.render('notification_link', {
-        into: 'application',
-        outlet: 'notification_link',
-        controller: 'notification_link'
+      this.render("notification_link", {
+        into: "application",
+        outlet: "notification_link",
+        controller: "notification_link"
       });
 
-      this.render('internet_call_status', {
-        into: 'application',
-        outlet: 'internet_call_status',
-        controller: 'internet_call_status'
+      this.render("internet_call_status", {
+        into: "application",
+        outlet: "internet_call_status",
+        controller: "internet_call_status"
       });
     }
   },
 
-
-
   offlineError(reason) {
-    if (!this.get('isOfflineErrAlreadyShown')) {
-      this.set('isOfflineErrAlreadyShown', true);
+    if (!this.get("isOfflineErrAlreadyShown")) {
+      this.set("isOfflineErrAlreadyShown", true);
       this.get("messageBox").alert(this.get("i18n").t("offline_error"), () => {
-        this.set('isOfflineErrAlreadyShown', false);
+        this.set("isOfflineErrAlreadyShown", false);
       });
       if (!reason.isAdapterError) {
         this.get("logger").error(reason);
@@ -135,19 +169,25 @@ export default Ember.Route.extend(preloadDataMixin, {
   },
 
   getErrorMessage(reason) {
-    if (reason.errors.length && reason.errors[0].detail && reason.errors[0].detail.status == 422) {
-      return reason.errors[0].detail.message;
-    } else {
-      return this.get("i18n").t("unexpected_error");
-    } 
+    const defaultMessage = this.get("i18n").t("unexpected_error");
+
+    return (
+      getString(reason, "errors[0].detail.message") ||
+      getString(reason, "errors[0].message") ||
+      getString(reason, "errors[0].title") ||
+      getString(reason, "errors[0]") ||
+      getString(reason, "message") ||
+      getString(reason, "error") ||
+      defaultMessage
+    );
   },
 
   showErrorPopup(reason) {
     this.get("logger").error(reason);
-    if (!this.get('isErrPopUpAlreadyShown')) {
-      this.set('isErrPopUpAlreadyShown', true);
+    if (!this.get("isErrPopUpAlreadyShown")) {
+      this.set("isErrPopUpAlreadyShown", true);
       this.get("messageBox").alert(this.getErrorMessage(reason), () => {
-        this.set('isErrPopUpAlreadyShown', false);
+        this.set("isErrPopUpAlreadyShown", false);
       });
     }
   },
@@ -158,15 +198,19 @@ export default Ember.Route.extend(preloadDataMixin, {
   },
 
   unauthorizedError() {
-    if (this.session.get('isLoggedIn')) {
-      this.controllerFor("application").send('logMeOut');
+    if (this.session.get("isLoggedIn")) {
+      this.controllerFor("application").send("logMeOut");
     }
   },
 
   handleError: function(reason) {
     try {
       var status;
-      try { status = parseInt(reason.errors[0].status, 10); } catch (err) { status = reason.status; }
+      try {
+        status = parseInt(reason.errors[0].status, 10);
+      } catch (err) {
+        status = reason.status;
+      }
 
       if (!window.navigator.onLine) {
         this.offlineError(reason);
@@ -199,8 +243,10 @@ export default Ember.Route.extend(preloadDataMixin, {
       if (this._loadingView) {
         return;
       }
-      this._loadingView = getOwner(this).lookup('component:loading').append();
-      this.router.one('didTransition', () => {
+      this._loadingView = getOwner(this)
+        .lookup("component:loading")
+        .append();
+      this.router.one("didTransition", () => {
         this._loadingView.destroy();
         this._loadingView = null;
       });
@@ -209,9 +255,15 @@ export default Ember.Route.extend(preloadDataMixin, {
     // so in this scenario redirect to home for 404
     error(reason) {
       try {
-        var errorStatus = parseInt(reason.status || reason.errors && reason.errors[0].status, 10);
+        var errorStatus = parseInt(
+          reason.status || (reason.errors && reason.errors[0].status),
+          10
+        );
         if ([403, 404].indexOf(errorStatus) >= 0) {
-          this.get("messageBox").alert(this.get("i18n").t(errorStatus + "_error"), () => this.transitionTo("/"));
+          this.get("messageBox").alert(
+            this.get("i18n").t(errorStatus + "_error"),
+            () => this.transitionTo("/")
+          );
         } else {
           this.handleError(reason);
         }
@@ -227,7 +279,7 @@ export default Ember.Route.extend(preloadDataMixin, {
 
         // remove joyride-popup if not assigned for page
         if ($(".joyride-list").length === 0) {
-          Ember.$('.joyride-tip-guide').remove();
+          Ember.$(".joyride-tip-guide").remove();
         }
       });
     }


### PR DESCRIPTION
Errors coming from the adapter do not carry on the message of the server error
The same message ends up appearing on every page whenever the backend returns an error.

This PR fixes that by injecting our own error message and data into the standard ember error
