### PR TITLE
Add sanitization for links coming out of db

### DIFF
--- a/app/helpers/apply-line-break.js
+++ b/app/helpers/apply-line-break.js
@@ -3,5 +3,7 @@ import Ember from "ember";
 export default Ember.Helper.helper(function(value) {
   value = new Ember.Handlebars.SafeString(value[0] || "").string;
   value = value.replace(/(\r\n|\n|\r)/gm, "<br>");
-  return new Ember.String.htmlSafe(value);
+  return new Ember.String.htmlSafe(
+    Ember.Handlebars.Utils.escapeExpression(value)
+  );
 });

--- a/app/helpers/apply-line-break.js
+++ b/app/helpers/apply-line-break.js
@@ -1,12 +1,7 @@
 import Ember from "ember";
 
 export default Ember.Helper.helper(function(value) {
-  var text;
-  if(/<[a-z][\s\S]*>/i.test(value)) {
-    text = value;
-  } else {
-    text = Ember.Handlebars.Utils.escapeExpression(value);
-    text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
-  }
-  return new Ember.Handlebars.SafeString(text);
+  value = new Ember.Handlebars.SafeString(value[0] || "").string;
+  value = value.replace(/(\r\n|\n|\r)/gm, "<br>");
+  return new Ember.String.htmlSafe(value);
 });

--- a/app/models/message.js
+++ b/app/models/message.js
@@ -30,6 +30,36 @@ export default DS.Model.extend({
     return true;
   }),
 
+  parsedBody: Ember.computed("body", function() {
+    let body = this.get("body");
+    body = body.replace(/(<br>)/gm, "\n");
+    body = body.replace(/(<)/g, "&lt;");
+    var offerId = this.get("messageableId");
+
+    let hrefExpressionMatch = body.match(
+      /\&lt;a href=(.*?)\>(.*?)\&lt;\/a\s*?\>/
+    );
+    if (hrefExpressionMatch) {
+      body = this.sanitizingAnchorLinks(body, offerId, hrefExpressionMatch);
+    }
+    return body;
+  }),
+
+  sanitizingAnchorLinks(body, offerId, hrefExpressionMatch) {
+    let originalLink = hrefExpressionMatch[0];
+    let anchorLink = hrefExpressionMatch[1];
+    let text = hrefExpressionMatch[2];
+    if (
+      anchorLink.includes(`offers/${offerId}/plan_delivery`) ||
+      anchorLink.includes(
+        "crossroads-foundation.formstack.com/forms/goodcity_feedback"
+      )
+    ) {
+      body = body.replace(originalLink, `<a href=${anchorLink}>${text}</a>`);
+    }
+    return body;
+  },
+
   createdDate: Ember.computed(function() {
     return new Date(this.get("createdAt")).toDateString();
   }),

--- a/app/templates/message_template.hbs
+++ b/app/templates/message_template.hbs
@@ -21,7 +21,7 @@
                   {{display-datetime message.createdAt format="HH:mm"}}
                 </div>
 
-                {{{apply-line-break message.body}}}
+                {{{apply-line-break message.parsedBody}}}
               </div>
             {{else}}
               <div class="small-12 columns item_log">


### PR DESCRIPTION
Added parsedBody method in message model to only whitelist feedback and transport link. This will prevent any other script to surpass and also backward compatibility can be achieved.